### PR TITLE
Use 20MHz, not 24MHz, master clock

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,6 @@ Usage Example
         vsync=board.CAMERA_VSYNC,
         href=board.CAMERA_HREF,
         mclk=board.CAMERA_XCLK,
-        mclk_frequency=24_000_000,
         size=adafruit_ov5640.OV5640_SIZE_QQVGA,
     )
     print("print chip id")

--- a/adafruit_ov5640.py
+++ b/adafruit_ov5640.py
@@ -818,7 +818,7 @@ class OV5640(_SCCB16CameraBase):  # pylint: disable=too-many-instance-attributes
         shutdown=None,
         reset=None,
         mclk=None,
-        mclk_frequency=24_000_000,
+        mclk_frequency=20_000_000,
         i2c_address=0x3C,
         size=OV5640_SIZE_QQVGA,
     ):  # pylint: disable=too-many-arguments
@@ -838,7 +838,11 @@ class OV5640(_SCCB16CameraBase):  # pylint: disable=too-many-instance-attributes
                 master clock signal, or None if the master clock signal is
                 already being generated.
             mclk_frequency (int): The frequency of the master clock to generate, \
-                ignored if mclk is None, requred if it is specified
+                ignored if mclk is None, requred if it is specified.
+                Note that the OV5640 requires a very low jitter clock,
+                so only specific (microcontroller-dependent) values may
+                work reliably.  On the ESP32-S2, a 20MHz clock can be generated
+                with sufficiently low jitter.
             i2c_address (int): The I2C address of the camera.
         """
 

--- a/examples/ov5640_directio_kaluga1_3_ili9341.py
+++ b/examples/ov5640_directio_kaluga1_3_ili9341.py
@@ -74,7 +74,6 @@ cam = adafruit_ov5640.OV5640(
     vsync=board.CAMERA_VSYNC,
     href=board.CAMERA_HREF,
     mclk=board.CAMERA_XCLK,
-    mclk_frequency=24_000_000,
     size=adafruit_ov5640.OV5640_SIZE_QVGA,
 )
 

--- a/examples/ov5640_sdcard_kaluga_1_3.py
+++ b/examples/ov5640_sdcard_kaluga_1_3.py
@@ -46,7 +46,6 @@ cam = adafruit_ov5640.OV5640(
     vsync=board.CAMERA_VSYNC,
     href=board.CAMERA_HREF,
     mclk=board.CAMERA_XCLK,
-    mclk_frequency=24_000_000,
     size=adafruit_ov5640.OV5640_SIZE_QSXGA,
 )
 

--- a/examples/ov5640_simpletest.py
+++ b/examples/ov5640_simpletest.py
@@ -38,7 +38,6 @@ cam = adafruit_ov5640.OV5640(
     vsync=board.CAMERA_VSYNC,
     href=board.CAMERA_HREF,
     mclk=board.CAMERA_XCLK,
-    mclk_frequency=24_000_000,
     size=adafruit_ov5640.OV5640_SIZE_QQVGA,
 )
 print("print chip id")


### PR DESCRIPTION
The clock module requires a very low jitter clock.  The esp32-s2 can do this with a 20MHz clock but not a 24MHz one, because it is dividing an internal clock of 80MHz to generate it.
![image](https://user-images.githubusercontent.com/1517291/136594549-54b756be-05db-4ebc-a84a-78eeea3b0a1e.png)
