### PR TITLE
_set_size_and_colorspace: Boost pixel clock

### DIFF
--- a/adafruit_ov5640.py
+++ b/adafruit_ov5640.py
@@ -1065,7 +1065,7 @@ class OV5640(_SCCB16CameraBase):  # pylint: disable=too-many-instance-attributes
                 sys_mul = 180
             self._set_pll(False, sys_mul, 4, 2, False, 2, True, 4)
         else:
-            self._set_pll(False, 8, 1, 1, False, 1, True, 4)
+            self._set_pll(False, 32, 1, 1, False, 1, True, 4)
 
         self._set_colorspace()
 


### PR DESCRIPTION
@ladyada noticed that the pixel clock was very low, leading to a frame rate of just 7.6Hz from the camera.  Because the structure of the parallel capture driver means dropping at least half of all frames, this led to a really low LCD refresh rate of just 3.8Hz.

Bump the PLL multiplier for non-JPEG modes from 8 to 32.  This gives a capture framerate of about 30FPS and an LCD refresh rate of about 15Hz.

Going significantly higher (multiplier 48) gives a jumbled display, but even going slightly higher doesn't have a big effect on frame rate because the total LCD data transmission time of about 30ms starts to overlap with the next frame. Increasing the multiplier to 40 increases the capture frame rate to 40Hz but the LCD refresh rate decreaseds to just 13Hz, because only 1/3 of captured frames are displayed instead of 1/2.  This is highly dependent on the LCD resolution & speed.